### PR TITLE
open street maps instead of google maps

### DIFF
--- a/docs/Social/chipotle.md
+++ b/docs/Social/chipotle.md
@@ -8,16 +8,16 @@ tags:
 
 Manhattan:
 
-- [117 E 14th St, New York, NY 10003](https://goo.gl/maps/UnfyJcnXAQdkUf3e8): Close to Palladium and the quality is pretty good.
-- [405 6th Ave, New York, NY 10014](https://goo.gl/maps/o2faauS8GQhCdoTRA): Close to GCASL and the quality is decent. However, this store is about $1 more expensive than the one near Tandon (generally more expensive in Manhattan). 
-- [55 E 8th St Frnt 2, New York, NY 10003](https://goo.gl/maps/BSodEfvxoBc4eMwQ8): Also close to GCASL but the quality is consistently bad. Avoid this location if you can!
-- [625 Broadway, New York, NY 10012](https://goo.gl/maps/rBDUcLLf9c2L9H6t6): Close to the Broadway-Lafayette train station and the quality is good.
+- [117 E 14th St, New York, NY 10003](https://www.openstreetmap.org/node/3071111733): Close to Palladium and the quality is pretty good.
+- [405 6th Ave, New York, NY 10014](https://www.openstreetmap.org/node/10709962653): Close to GCASL and the quality is decent. However, this store is about $1 more expensive than the one near Tandon (generally more expensive in Manhattan).
+- [55 E 8th St Frnt 2, New York, NY 10003](https://www.openstreetmap.org/node/2547165967): Also close to GCASL but the quality is consistently bad. Avoid this location if you can!
+- [625 Broadway, New York, NY 10012](https://www.openstreetmap.org/node/4255253129): Close to the Broadway-Lafayette train station and the quality is good.
 
 Brooklyn:
 
-- [1 MetroTech Center, Brooklyn, NY 11201](https://goo.gl/maps/Zhq3mnZryHnAY9g87): Close to Tandon so very convenient but it can also get crowded since everyone likes to go there during their lunch break. I would recommend trying to avoid between 12pm - 2pm. 
-- [474 Fulton St, Brooklyn, NY 11201](https://goo.gl/maps/jXwYPkGQEQn9rATt9): Close to Dekalb; it's decent but you should probably go to Dekalb.
+- [1 MetroTech Center, Brooklyn, NY 11201](https://www.openstreetmap.org/node/4557451331): Close to Tandon so very convenient but it can also get crowded since everyone likes to go there during their lunch break. I would recommend trying to avoid between 12pm - 2pm.
+- [474 Fulton St, Brooklyn, NY 11201](https://www.openstreetmap.org/node/9023863625): Close to Dekalb; it's decent but you should probably go to Dekalb.
 
-Bonus: 
+Bonus:
 
-- [345 Adams St, Brooklyn, NY 11201](https://goo.gl/maps/2qfGeAQkCpRbv8kFA): Cava - good Mediterranean alternative to Chipotle; more expensive but more filling.
+- [345 Adams St, Brooklyn, NY 11201](https://www.openstreetmap.org/node/4559289816): Cava - good Mediterranean alternative to Chipotle; more expensive but more filling.


### PR DESCRIPTION
Google Maps is not open source (there is also a lot more unsavory stuff that google does but...)

I would argue the open source club should use open source mapping software - Open Street Maps.

The third chipotle is not labeled correctly, but the address is still indexed into osm.