### PR TITLE
remove dalle from software used (as it is not being used)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,10 +171,6 @@ const config = {
                 label: 'NPM Packages',
                 href: `/docs/packages`,
               },
-              {
-                label: 'DALLE2',
-                href: 'https://openai.com/dall-e-2',
-              },
             ],
           },
 


### PR DESCRIPTION
Just remove dalle from the footer, as I think it is not being used for the images anymore.