### PR TITLE
Add `algolia` search

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -28,4 +28,4 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          TEST_ID: testSecret
+          TEST_ID: ${{ secrets.TEST_SECRET }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -28,3 +28,4 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+          TEST_ID: testSecret

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -11,6 +11,7 @@ jobs:
   test-deploy:
     name: Install, lint and build
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -28,4 +29,3 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          TEST_ID: ${{ secrets.TEST_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
+require('dotenv').config()
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
@@ -62,6 +63,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      algolia: {
+        appId: process.env.ALGOLIA_APP_ID,
+        apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
+        indexName: process.env.ALGOLIA_INDEX_NAME
+      },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.jpg',
       navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const repo = 'https://github.com/BUGS-NYU/nyu-cs-wiki';
 const branch = 'main'
 
+console.log(process.env.TEST_ID)
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'NYU CS Wiki',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,8 @@ const config = {
       algolia: {
         appId: process.env.ALGOLIA_APP_ID,
         apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
-        indexName: process.env.ALGOLIA_INDEX_NAME
+        indexName: process.env.ALGOLIA_INDEX_NAME,
+        placeholder: 'Search NYU CS Wiki'
       },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.jpg',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,8 +7,6 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const repo = 'https://github.com/BUGS-NYU/nyu-cs-wiki';
 const branch = 'main'
 
-console.log(process.env.TEST_ID)
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'NYU CS Wiki',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@docusaurus/eslint-plugin": "^2.4.1",
         "@docusaurus/module-type-aliases": "2.4.1",
+        "dotenv": "^16.3.1",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -7159,6 +7160,18 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@docusaurus/eslint-plugin": "^2.4.1",
     "@docusaurus/module-type-aliases": "2.4.1",
+    "dotenv": "^16.3.1",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",


### PR DESCRIPTION
Adds `algolia` integration (#47). Docusaurus comes with a preset for `algolia` search bar, all we need to do is setup the according API keys.

@calvinatian could you add those environment variables to the gh pages? I don't have access to the settings. I also sent you an invitation to join the `algolia` team for this project.