### PR TITLE
ADD lint-fix script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,4 @@ docs
 static
 package.json
 package-lock.json
-*.config.js
+build/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
   presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-};
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,15 +9,15 @@ const branch = 'main'
 
 function getAlgoliaConfig(config, requiredKeys = ['appId', 'apiKey', 'indexName']) {
   // filter missing required keys
-  const missingKeys = requiredKeys.filter(key => config[key] === undefined);
+  const missingKeys = requiredKeys.filter(key => config[key] === undefined)
 
   // if some keys are missing, return undefined
   if (missingKeys.length > 0) {
-    console.error(`Could not bootstrap Algolia search in docusaurus config, missing the following configuration values: ${missingKeys.join(',')}`);
-    return undefined;
+    console.error(`Could not bootstrap Algolia search in docusaurus config, missing the following configuration values: ${missingKeys.join(',')}`)
+    return undefined
   }
 
-  return config;
+  return config
 }
 
 /** @type {import('@docusaurus/types').Config} */

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,9 +2,9 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 require('dotenv').config()
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-const repo = 'https://github.com/BUGS-NYU/nyu-cs-wiki';
+const lightCodeTheme = require('prism-react-renderer/themes/github')
+const darkCodeTheme = require('prism-react-renderer/themes/dracula')
+const repo = 'https://github.com/BUGS-NYU/nyu-cs-wiki'
 const branch = 'main'
 
 /** @type {import('@docusaurus/types').Config} */
@@ -176,7 +176,7 @@ const config = {
             items: [
               {
                 label: 'NPM Packages',
-                href: `/docs/packages`,
+                href: '/docs/packages',
               },
             ],
           },
@@ -194,6 +194,6 @@ const config = {
         },
       },
     }),
-};
+}
 
-module.exports = config;
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint": "eslint \"**/*.{js,jsx}\"",
+    "lint-fix": "eslint --fix \"**/*.{js,jsx}\"",
     "format": "prettier --write \"**/*.{js,jsx,css,json}\""
   },
   "dependencies": {


### PR DESCRIPTION
* adds `lint-fix` script
* removes `*.config.js` from the `.eslintignore` file so linter runs on the docusaurus config file
* ran linter on config files
* adds the `build/` directory to the ignore file so linter does not complain about local builds
* adds `.gitattributes` file to enforce `lf` line endings with git
