### PR TITLE
Algolia empty key check

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ docs
 static
 package.json
 package-lock.json
+build/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          NODE_ENV: ${{ vars.NODE_ENV }}
+          NODE_ENV: production
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          NODE_ENV: production
+          ENVIRONMENT: production
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+          NODE_ENV: ${{ vars.NODE_ENV }}
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -29,3 +29,4 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+          NODE_ENV: ${{ vars.NODE_ENV }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -29,4 +29,4 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          NODE_ENV: ${{ vars.NODE_ENV }}
+          NODE_ENV: development

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -29,4 +29,4 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          NODE_ENV: development
+          ENVIRONMENT: development

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,11 @@ function getAlgoliaConfig(
 
   // if some keys are missing, return undefined
   if (missingKeys.length > 0) {
+    // require all keys in production
+    if (process.env.NODE_ENV == 'production') {
+      throw new Error('Missing Algolia config keys on production!')
+    }
+
     console.error(
       `Could not bootstrap Algolia search in docusaurus config, missing the following configuration values: ${missingKeys.join(
         ','

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,9 @@ function getAlgoliaConfig(
   requiredKeys = ['appId', 'apiKey', 'indexName']
 ) {
   // filter missing required keys
-  const missingKeys = requiredKeys.filter((key) => config[key] === undefined)
+  const missingKeys = requiredKeys.filter(
+    (key) => config[key] === undefined || config[key] === ''
+  )
 
   // if some keys are missing, return undefined
   if (missingKeys.length > 0) {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ function getAlgoliaConfig(
   // if some keys are missing, return undefined
   if (missingKeys.length > 0) {
     // require all keys in production
-    if (process.env.NODE_ENV == 'production') {
+    if (process.env.NODE_ENV === 'production') {
       throw new Error('Missing Algolia config keys on production!')
     }
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ function getAlgoliaConfig(
   // if some keys are missing, return undefined
   if (missingKeys.length > 0) {
     // require all keys in production
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.ENVIRONMENT === 'production') {
       throw new Error('Missing Algolia config keys on production!')
     }
 


### PR DESCRIPTION
Adds a check for empty keys. This is because secrets are not passed to runners from forks as a security concern. This should resolve #57.